### PR TITLE
Start and reset 25 minute work sessions

### DIFF
--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="aDoro">
+<html data-ng-app="aDoro">
   <head lang="en">
     <meta charset="UTF-8">
     <title>Awesomedoro!</title>
@@ -14,5 +14,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.13/angular-ui-router.min.js"></script>
     <script src="/scripts/app.js"></script>
     <script src="/scripts/controllers/HomeCtrl.js"></script>
+    <script src="/scripts/directives/sessionTimer.js"></script>
+    <script src="/scripts/filters/timecode.js"></script>
   </body>
 </html>

--- a/app/scripts/controllers/HomeCtrl.js
+++ b/app/scripts/controllers/HomeCtrl.js
@@ -1,10 +1,14 @@
 (function() {
-  var HomeCtrl = function HomeCtrl($scope, $firebaseArray) {
+  var HomeCtrl = function HomeCtrl($rootScope, $scope, $firebaseArray) {
     var ref = new Firebase('https://awesomedoro.firebaseio.com/');
     $scope.messages = $firebaseArray(ref);
+    $rootScope.$on('timerfinished', startBreak);
+    function startBreak() {
+      console.log('Break should start now');
+    }
   };
   
   angular
     .module('aDoro')
-    .controller('HomeCtrl', ['$scope', '$firebaseArray', HomeCtrl]);
+    .controller('HomeCtrl', ['$rootScope', '$scope', '$firebaseArray', HomeCtrl]);
 })();

--- a/app/scripts/directives/sessionTimer.js
+++ b/app/scripts/directives/sessionTimer.js
@@ -8,7 +8,10 @@
    * # sessionTimer
    */
   var sessionTimer = function sessionTimer($interval) {
+    // initialize duration of timer
+    // this should be turn into a variable, eventually
     var timerDuration = 1500;
+
     return {
       templateUrl: '/templates/directives/session_timer.html',
       replace: true,
@@ -20,6 +23,9 @@
         // intialize message object
         var currentTime = timerDuration;
         scope.Countdown = currentTime;
+
+        // initialize button state and handle toggle
+        scope.btnVisible = true;
         
         // start timer function
         scope.StartTimer = function() {
@@ -28,6 +34,8 @@
             currentTime--;
             scope.Countdown = currentTime;
           }, 1000);
+          // toggle button state from "start" to "reset"
+          scope.btnVisible = false;
         }
 
         // stop timer function
@@ -36,9 +44,11 @@
           // cancel the timer and reset the value
           if (angular.isDefined(scope.Timer)) {
             $interval.cancel(scope.Timer);
-            console.log(timerDuration);
             currentTime = timerDuration;
             scope.Countdown = timerDuration;
+            
+            // reset button state from "reset" to "start"
+            scope.btnVisible = true;
           }
         }
       }

--- a/app/scripts/directives/sessionTimer.js
+++ b/app/scripts/directives/sessionTimer.js
@@ -1,0 +1,46 @@
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc directive
+   * @name aDoro.directive:sessionTimer
+   * @description
+   * # sessionTimer
+   */
+  var sessionTimer = function sessionTimer($interval) {
+    return {
+      templateUrl: '/templates/directives/session_timer.html',
+      replace: true,
+      restrict: 'E',
+      scope: {},
+      link: function(scope, element, attributes) {
+        // initialize timer object
+        scope.Timer = null;
+        // intialize message object
+        var currentTime = 1500;
+        scope.Countdown = currentTime;
+        
+        // start timer function
+        scope.StartTimer = function() {
+          // initialize the timer to run every 1000 milliseconds (1 second tick)
+          scope.Timer = $interval(function() {
+            currentTime--;
+            scope.Countdown = currentTime;
+          }, 1000);
+        }
+
+        // stop timer function
+        scope.StopTimer = function() {
+          scope.Countdown = 'Timer stopped.';
+          // cancel the timer
+          if (angular.isDefined(scope.Timer)) {
+            $interval.cancel(scope.Timer);
+          }
+        }
+      }
+    };
+  };
+  angular
+      .module('aDoro')
+      .directive('sessionTimer', ['$interval', sessionTimer])
+})();

--- a/app/scripts/directives/sessionTimer.js
+++ b/app/scripts/directives/sessionTimer.js
@@ -7,20 +7,22 @@
    * @description
    * # sessionTimer
    */
-  var sessionTimer = function sessionTimer($interval) {
-    // initialize duration of timer
-    // this should be turn into a variable, eventually
-    var timerDuration = 10;
+  var sessionTimer = function sessionTimer($rootScope, $interval) {
 
     return {
       templateUrl: '/templates/directives/session_timer.html',
       replace: true,
       restrict: 'E',
-      scope: {},
+      scope: {
+        duration: '='
+      },
       link: function(scope, element, attributes) {
+        // initialize timer duration
+        var timerDuration = scope.duration || 25;
+        var timerDuration = timerDuration * 60;
         // initialize timer object
         scope.Timer = null;
-        // intialize message object
+        // intialize countdown object
         var currentTime = timerDuration;
         scope.Countdown = currentTime;
 
@@ -37,6 +39,8 @@
             // when the timer reaches zero, stop the countdown
             if (currentTime === 0) {
               $interval.cancel(scope.Timer);
+              // broadcast the state change
+              $rootScope.$broadcast('timerfinished');
             }
           }, 1000);
           // toggle button state from "start" to "reset"
@@ -45,8 +49,10 @@
 
         // stop timer function
         scope.StopTimer = function() {
-          // cancel the timer and reset the value
+        
           if (angular.isDefined(scope.Timer)) {
+
+            // cancel the timer and reset the value to the original duration
             $interval.cancel(scope.Timer);
             currentTime = timerDuration;
             scope.Countdown = timerDuration;
@@ -60,5 +66,5 @@
   };
   angular
       .module('aDoro')
-      .directive('sessionTimer', ['$interval', sessionTimer])
+      .directive('sessionTimer', ['$rootScope', '$interval', sessionTimer])
 })();

--- a/app/scripts/directives/sessionTimer.js
+++ b/app/scripts/directives/sessionTimer.js
@@ -10,7 +10,7 @@
   var sessionTimer = function sessionTimer($interval) {
     // initialize duration of timer
     // this should be turn into a variable, eventually
-    var timerDuration = 1500;
+    var timerDuration = 10;
 
     return {
       templateUrl: '/templates/directives/session_timer.html',
@@ -33,6 +33,11 @@
           scope.Timer = $interval(function() {
             currentTime--;
             scope.Countdown = currentTime;
+
+            // when the timer reaches zero, stop the countdown
+            if (currentTime === 0) {
+              $interval.cancel(scope.Timer);
+            }
           }, 1000);
           // toggle button state from "start" to "reset"
           scope.btnVisible = false;
@@ -40,13 +45,12 @@
 
         // stop timer function
         scope.StopTimer = function() {
-          scope.Countdown = 'Timer stopped.';
           // cancel the timer and reset the value
           if (angular.isDefined(scope.Timer)) {
             $interval.cancel(scope.Timer);
             currentTime = timerDuration;
             scope.Countdown = timerDuration;
-            
+
             // reset button state from "reset" to "start"
             scope.btnVisible = true;
           }

--- a/app/scripts/directives/sessionTimer.js
+++ b/app/scripts/directives/sessionTimer.js
@@ -8,6 +8,7 @@
    * # sessionTimer
    */
   var sessionTimer = function sessionTimer($interval) {
+    var timerDuration = 1500;
     return {
       templateUrl: '/templates/directives/session_timer.html',
       replace: true,
@@ -17,7 +18,7 @@
         // initialize timer object
         scope.Timer = null;
         // intialize message object
-        var currentTime = 1500;
+        var currentTime = timerDuration;
         scope.Countdown = currentTime;
         
         // start timer function
@@ -32,9 +33,12 @@
         // stop timer function
         scope.StopTimer = function() {
           scope.Countdown = 'Timer stopped.';
-          // cancel the timer
+          // cancel the timer and reset the value
           if (angular.isDefined(scope.Timer)) {
             $interval.cancel(scope.Timer);
+            console.log(timerDuration);
+            currentTime = timerDuration;
+            scope.Countdown = timerDuration;
           }
         }
       }

--- a/app/scripts/filters/timecode.js
+++ b/app/scripts/filters/timecode.js
@@ -1,0 +1,28 @@
+(function() {
+  var timecode = function timecode() {
+    return function(seconds) {
+
+      if (Number.isNaN(seconds)) {
+        return '-:--';
+      }
+
+      var seconds = Number.parseFloat(seconds);
+      var wholeSeconds = Math.floor(seconds);
+      var minutes = Math.floor(wholeSeconds / 60);
+      var remainingSeconds = wholeSeconds % 60;
+
+      var output = minutes + ':';
+
+      if (remainingSeconds < 10) {
+        output += '0';   
+      }
+
+      output += remainingSeconds;
+      return output;
+    };
+  };
+
+  angular
+    .module('aDoro')
+    .filter('timecode', timecode);
+ })();

--- a/app/scripts/filters/timecode.js
+++ b/app/scripts/filters/timecode.js
@@ -11,12 +11,14 @@
       var minutes = Math.floor(wholeSeconds / 60);
       var remainingSeconds = wholeSeconds % 60;
 
+      if (minutes === 0) {
+        minutes += '0';
+      }
       var output = minutes + ':';
 
       if (remainingSeconds < 10) {
         output += '0';   
       }
-
       output += remainingSeconds;
       return output;
     };

--- a/app/templates/directives/session_timer.html
+++ b/app/templates/directives/session_timer.html
@@ -1,5 +1,5 @@
 <div>
-  <div ng-bind="Countdown">{{ home.sessionTimer.Countdown |timecode }}</div>
+  <span>{{ Countdown | timecode }}</span>
   <br />
   <input type="button" value="Start a Work Session" ng-click="StartTimer()" ng-show="btnVisible" />
   <input type="button" value="Reset Timer" ng-click="StopTimer()" ng-show="!btnVisible" />

--- a/app/templates/directives/session_timer.html
+++ b/app/templates/directives/session_timer.html
@@ -1,6 +1,6 @@
 <div>
   <div ng-bind="Countdown">{{ home.sessionTimer.Countdown |timecode }}</div>
   <br />
-  <input type="button" value="Start Timer" ng-click="StartTimer()" ng-show="btnVisible" />
+  <input type="button" value="Start a Work Session" ng-click="StartTimer()" ng-show="btnVisible" />
   <input type="button" value="Reset Timer" ng-click="StopTimer()" ng-show="!btnVisible" />
 </div>

--- a/app/templates/directives/session_timer.html
+++ b/app/templates/directives/session_timer.html
@@ -1,6 +1,6 @@
 <div>
   <div ng-bind="Countdown">{{ home.sessionTimer.Countdown |timecode }}</div>
   <br />
-  <input type="button" value="Start Timer" ng-click="StartTimer()" />
-  <input type="button" value="Stop Timer" ng-click="StopTimer()" />
+  <input type="button" value="Start Timer" ng-click="StartTimer()" ng-show="btnVisible" />
+  <input type="button" value="Reset Timer" ng-click="StopTimer()" ng-show="!btnVisible" />
 </div>

--- a/app/templates/directives/session_timer.html
+++ b/app/templates/directives/session_timer.html
@@ -1,0 +1,6 @@
+<div>
+  <div ng-bind="Countdown">{{ home.sessionTimer.Countdown |timecode }}</div>
+  <br />
+  <input type="button" value="Start Timer" ng-click="StartTimer()" />
+  <input type="button" value="Stop Timer" ng-click="StopTimer()" />
+</div>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,3 +1,3 @@
 <div data-ng-controller="HomeCtrl as home">
-  <session-timer></session-timer>
+  <session-timer duration="25"></session-timer>
 </div>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,1 +1,3 @@
-<h1>Home Page</h1>
+<div data-ng-controller="HomeCtrl as home">
+  <session-timer></session-timer>
+</div>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "path": "^0.4.9"
   },
   "devDependencies": {
+    "angular-mocks": "^1.5.0",
     "connect-modrewrite": "^0.7.9",
     "es5-shim": "^4.0.1",
     "grunt": "^0.4.5",
@@ -25,11 +26,14 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-hapi": "^0.8.1",
+    "grunt-html2js": "^0.3.5",
     "grunt-karma": "^0.12.1",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-chrome-launcher": "^0.2.2",
-    "karma-jasmine": "^0.3.7"
+    "karma-jasmine": "^0.3.7",
+    "karma-jasmine-jquery": "^0.1.1",
+    "karma-ng-html2js-preprocessor": "^0.2.1"
   }
 }

--- a/spec/SessionTimerSpec-pass.js
+++ b/spec/SessionTimerSpec-pass.js
@@ -1,0 +1,19 @@
+describe('sessionTimer.js', function() {
+
+  it('confirms that the session_timer directive exists', function() {
+
+  });
+
+  it('ensures user can start work session', function() {});
+
+  it('ensures user can reset current work session', function() {});
+
+  it('ensures that the counter reads "25:00" when application loads', function() {});
+
+  it('ensures that the counter reads "25:00" when timer is reset', function() {});
+
+  it('ensures that the counter readout decrements by 1 second per second when work session is active', function() {});
+
+  it('ensures work session counter reads "00:00" twenty-five minutes after work session was started', function() {});
+
+});

--- a/spec/sampleDirectivesSpec.js
+++ b/spec/sampleDirectivesSpec.js
@@ -1,0 +1,19 @@
+var compile, scope, directiveElem;
+
+beforeEach(function(){
+  module('sampleDirectives');
+  
+  inject(function($compile, $rootScope){
+    compile = $compile;
+    scope = $rootScope.$new();
+  });
+  
+  directiveElem = getCompiledElement();
+});
+
+function getCompiledElement(){
+  var element = angular.element('<div first-directive></div>');
+  var compiledElement = compile(element)(scope);
+  scope.$digest();
+  return compiledElement;
+}

--- a/spec/sessionTimerSpec.js
+++ b/spec/sessionTimerSpec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('Directive: sessionTimer', function () {
+
+  // load the directive's module
+  beforeEach(module('aDoro'));
+
+  var element,
+    scope;
+
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+  }));
+
+  it('should make hidden element visible', inject(function ($compile) {
+    element = angular.element('<session-timer></session-timer>');
+    element = $compile(element)(scope);
+    expect(element.text()).toBe('this is the sessionTimer directive');
+  }));
+});

--- a/spec/support/index.html
+++ b/spec/support/index.html
@@ -1,0 +1,18 @@
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.3/jasmine.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.3/jasmine.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.3/jasmine-html.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.3/boot.min.js"></script>
+    </head>
+    <body>
+    </body>
+    <script type="text/javascript">
+
+        // Paste in the test code here.
+        describe('calculator', function () {
+            it('1 + 1 should equal 2');
+        });
+
+    </script>
+</html>

--- a/spec/support/karma.conf.js
+++ b/spec/support/karma.conf.js
@@ -10,12 +10,15 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine-jquery', 'jasmine'],
 
 
     // list of files / patterns to load in the browser
     files: [
+      // using angular from cdn
+      'https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular.min.js',
       '../../app/**/*.js',
+      '../../app/**/*.html',
       '../**/*[sS]pec.js'
     ],
 
@@ -28,6 +31,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+        '**/*.html': ['ng-html2js']
     },
 
 
@@ -47,7 +51,7 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
+    logLevel: config.LOG_DEBUG,
 
 
     // enable / disable watching file and executing tests whenever any file changes
@@ -65,6 +69,7 @@ module.exports = function(config) {
 
     // Concurrency level
     // how many browser should be started simultaneous
-    concurrency: Infinity
+    concurrency: Infinity,
+    
   })
 }


### PR DESCRIPTION
New `sessionTimer` directive used to start and reset a countdown timer.

<strike>NOTE: The `timecode` filter isn't working as expected and will need review. Right now it isn't correctly reformatting the `currentTime` value from a number to the `MM:SS` format as designed.</strike>